### PR TITLE
Add ability to generate and regenerate in parts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Steps to generate HTML:
 3. Run `make html`. All the html files should be in `build/html`. You can change styling by editing `generate_html/template.html`.
 
 
-### Generate entire collection in sections
+### Generate entire collection in parts
 
 🧪 BETA FEATURE
 
@@ -606,8 +606,8 @@ Let's say you want to generate a 10k collection with 100 frames each. Most compu
 to handle hundreds of GB of data, plus the whole process can take days and might get interrupted halfway.
 
 Instead of paying for a remote server and having to pay for tons of storage, now you can run
-the whole generation process locally in sections! This is different than the "batching" mentioned above, which
-batches the frames into smaller batches, this means you can generate only certain editions at a time.
+the whole generation process locally in parts! This is different than the "batching" mentioned in previous sections, which
+batches the frames into smaller batches. Generating in parts means you can generate only part of the collection at a time.
 
 For example, let's say you have a 10k collection with 120 frames. Your global config might look like:
 ```
@@ -621,7 +621,7 @@ For example, let's say you have a 10k collection with 120 frames. Your global co
 }
 ```
 
-Now instead of just running `make all` which will most likely error, you will need to edit `all.py`.
+Now instead of just running `make all` which will most likely error, you can genereate only 1k editions at a time. You will need to edit `all.py`.
 
 Look for `START_EDITION` and `END_EDITION`. These are going to be which range of editions you want to generate. For example first we could generate 0 - 1000. Edit the file with `START_EDITION = 0`, and `END_EDITION = 1000`. This under the hood will generate all 10K JSON files, but only generate the first 1K. You can check rarity and other metadata info now. **NOTE** `END_EDITION` is EXCLUSIVE, meaning this will only generate 0 - 999 (total of 1000).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Welcome to the **Generative Animated Engine v3.1.1** 🐤
+# Welcome to the **Generative Animated Engine v3.1.2** 🐤
 
-[8 minute read]
+[10 minute read]
 
 **This repo used to be called jalagar/Generative_Gif_Engine but because it now supports GIF, MP4, it was renamed to jalagar/animated-art-engine. v3.0.0 is the beginning of the animated era.**
 
@@ -596,6 +596,37 @@ Steps to generate HTML:
 2. Have all your PFPs in the `build/pfps` folder. You can do this by running `make all` with `generatePFP` set to `true`. You can pick which frame to be your PFPs in `pfpFrameNumber`. OR you can just drag the PFPs if you already have them generated.
 3. Change the logo to your logo in `generate_html/logo.png`. It has to be called `logo.png` all lowercase.
 3. Run `make html`. All the html files should be in `build/html`. You can change styling by editing `generate_html/template.html`.
+
+
+### Generate entire collection in sections
+
+🧪 BETA FEATURE
+
+Let's say you want to generate a 10k collection with 100 frames each. Most computers don't have enough space
+to handle hundreds of GB of data, plus the whole process can take days and might get interrupted halfway.
+
+Instead of paying for a remote server and having to pay for tons of storage, now you can run
+the whole generation process locally in sections! This is different than the "batching" mentioned above, which
+batches the frames into smaller batches, this means you can generate only certain editions at a time.
+
+For example, let's say you have a 10k collection with 120 frames. Your global config might look like:
+```
+{
+        "totalSupply": 10000,
+        ...
+        "startIndex": 0,
+        ...
+        "useBatches": true,
+        "numFramesPerBatch": 20
+}
+```
+
+Now instead of just running `make all` which will most likely error, you will need to edit `all.py`.
+
+Look for `START_EDITION` and `END_EDITION`. These are going to be which range of editions you want to generate. For example first we could generate 0 - 1000. Edit the file with `START_EDITION = 0`, and `END_EDITION = 1000`. This under the hood will generate all 10K JSON files, but only generate the first 1K. You can check rarity and other metadata info now. **NOTE** `END_EDITION` is EXCLUSIVE, meaning this will only generate 0 - 999 (total of 1000).
+
+After this finishes, move the `build` folder to somewhere else on your computer, or an external hard
+drive, and start generating `START_EDITION = 1000` and `END_EDITION = 2000`. This will generate 1000 - 1999. Repeat the process until (making sure to move the files out of the build folder), `START_EDITION = 9000` to `END_EDITION = 10000`.
 
 
 ### Preview Gif/MP4

--- a/all.py
+++ b/all.py
@@ -3,6 +3,8 @@ from step3_generative_sheet_to_output.build import main as step3_main
 import subprocess
 from utils.file import parse_global_config
 import multiprocessing
+import shutil
+import os
 
 global_config_json = parse_global_config()
 num_total_frames = global_config_json["numberOfFrames"]
@@ -18,6 +20,27 @@ start_index = global_config_json["startIndex"]
 height = global_config_json["height"]
 width = global_config_json["width"]
 
+"""
+Override START_EDITION and END_EDITION if you want to run in batches.
+Default values:
+START_EDITION = start_index
+END_EDITION = start_index + total_supply
+
+Ex. You have a 10k collection but it takes too long to render the entire collection. You would first do
+START_EDITION = start_index
+END_EDITION = 1000 (exclusive)
+
+This would generate all 10k JSON files, but only generate the NFTs for the first 1K.
+
+Then you can move these NFTs to another folder, and then change:
+START_EDITION = 1000
+END_EDITION = 2000
+etc...
+
+NOTE END_EDITION is exclusive, so if start_index is 0 and you have 10k collection, END_EDITION would be 10001
+"""
+START_EDITION = start_index
+END_EDITION = start_index + total_supply
 
 def create_from_dna(edition, num_frames_per_batch=num_frames_per_batch):
     override_width = num_frames_per_batch * width
@@ -37,7 +60,7 @@ def create_all_from_dna(num_frames_per_batch=num_frames_per_batch):
 
         args = [
             (edition, num_frames_per_batch)
-            for edition in range(start_index, start_index + total_supply)
+            for edition in range(START_EDITION, END_EDITION)
         ]
         with multiprocessing.Pool(processor_count) as pool:
             pool.starmap(
@@ -46,24 +69,32 @@ def create_all_from_dna(num_frames_per_batch=num_frames_per_batch):
             )
     else:
         # Then recreate DNA from the editions
-        for edition in range(start_index, start_index + total_supply):
+        for edition in range(START_EDITION, END_EDITION):
             create_from_dna(edition, num_frames_per_batch)
 
 
 def main():
+    if START_EDITION == start_index:
+        print("********CREATING INITIAL JSON*******")
+        # run step 1 with one pixel dimensions to speed up JSON processing and generate hashes
+        step1_main(0, height=1, width=1)
+        subprocess.run(
+            f"cd step2_spritesheet_to_generative_sheet && npm run generate 1 1 && cd ..",
+            shell=True,
+        )
+
+    print("********STARTING REGENERATION PROCESS*******")
     for i in range(num_total_frames // num_frames_per_batch):
         if use_batching:
             print(f"*******Starting Batch {i}*******")
         step1_main(i)
-        # For first batch, run step2 normally to generate hashes
-        if i == 0:
-            subprocess.run(
-                f"make step2",
-                shell=True,
-            )
-        else:
-            create_all_from_dna()
-        # Only generate gif if its the last batch
+
+        # Remove step 2 folders to reset the editions
+        shutil.rmtree("step2_spritesheet_to_generative_sheet/output/images")
+        os.mkdir("step2_spritesheet_to_generative_sheet/output/images")
+        create_all_from_dna()
+
+        # Only generate animations if its the last batch
         step3_main(
             i,
             should_generate_output=i == (num_total_frames // num_frames_per_batch - 1),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Generative_Gif_Engine",
+  "name": "animated-art-engine",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}

--- a/step2_spritesheet_to_generative_sheet/index.js
+++ b/step2_spritesheet_to_generative_sheet/index.js
@@ -16,10 +16,10 @@ const { startCreating, buildSetup } = require(path.join(
 
 program
   .name("generate")
-
-  .option("-c, --continue <dna>", "Continues generation using a _dna.json file")
+  .option("--continue <dna>", "Continues generation using a _dna.json file")
+  .option("--height <height>", "Override height")
+  .option("--width <width>", "Override width")
   .action((options) => {
-    console.log(chalk.green("generator started"), options.continue);
     options.continue
       ? console.log(
         chalk.bgCyanBright("\n continuing generation using _dna.json file \n")
@@ -32,8 +32,13 @@ program
       dna = new Set(storedGenomes);
       console.log({ dna });
     }
+    const args = program.args;
+    if (args.length == 2) {
+      startCreating(dna, parseInt(args[0]), parseInt(args[1]));
+    } else {
+      startCreating(dna, null, null);
+    }
 
-    startCreating(dna);
   });
 
-program.parse();
+program.parse(process.argv);

--- a/step2_spritesheet_to_generative_sheet/package-lock.json
+++ b/step2_spritesheet_to_generative_sheet/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "nft-gif-generator",
-  "version": "3.1.0",
+  "name": "nft-animated-generator",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nft-gif-generator",
-      "version": "3.1.0",
+      "name": "nft-animated-generator",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "canvas": "^2.8.0",
@@ -17,7 +17,7 @@
         "sharp": "^0.30.5"
       },
       "bin": {
-        "nft-gif-generator": "index.js"
+        "nft-animated-generator": "index.js"
       },
       "engines": {
         "node": ">=14"

--- a/step2_spritesheet_to_generative_sheet/package.json
+++ b/step2_spritesheet_to_generative_sheet/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nft-gif-generator",
-  "version": "3.1.1",
+  "name": "nft-animated-generator",
+  "version": "3.1.2",
   "description": "Jalagar Fork off of NFTChef Fork - Hard fork from HashLips Art Engine, is a tool used to create multiple different instances of animated artworks based on provided layers. Most config is the same as Hashlips",
   "main": "index.js",
   "bin": "index.js",


### PR DESCRIPTION
## Generate entire collection in parts

🧪 BETA FEATURE

Let's say you want to generate a 10k collection with 100 frames each. Most computers don't have enough space
to handle hundreds of GB of data, plus the whole process can take days and might get interrupted halfway.

Instead of paying for a remote server and having to pay for tons of storage, now you can run
the whole generation process locally in parts! This is different than the "batching" mentioned in previous sections, which
batches the frames into smaller batches. Generating in parts means you can generate only part of the collection at a time.

For example, let's say you have a 10k collection with 120 frames. Your global config might look like:
```
{
        "totalSupply": 10000,
        ...
        "startIndex": 0,
        ...
        "useBatches": true,
        "numFramesPerBatch": 20
}
```

Now instead of just running `make all` which will most likely error, you can genereate only 1k editions at a time. You will need to edit `all.py`.

Look for `START_EDITION` and `END_EDITION`. These are going to be which range of editions you want to generate. For example first we could generate 0 - 1000. Edit the file with `START_EDITION = 0`, and `END_EDITION = 1000`. This under the hood will generate all 10K JSON files, but only generate the first 1K. You can check rarity and other metadata info now. **NOTE** `END_EDITION` is EXCLUSIVE, meaning this will only generate 0 - 999 (total of 1000).

After this finishes, move the `build` folder to somewhere else on your computer, or an external hard
drive, and start generating `START_EDITION = 1000` and `END_EDITION = 2000`. This will generate 1000 - 1999. Repeat the process until (making sure to move the files out of the build folder), `START_EDITION = 9000` to `END_EDITION = 10000`.
